### PR TITLE
lsコマンドを作る2：-aオプションが使えるlsコマンドを実装する

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -2,6 +2,29 @@
 
 require 'optparse'
 
+def main
+  formatted_list = []
+  opt = OptionParser.new
+  opt.on('-a') do
+    files_and_dirs_name = Dir.entries('.')
+    formatted_list = push_elem_to_three_lists(files_and_dirs_name.sort)
+  end
+  opt.parse!(ARGV)
+
+  if formatted_list.empty?
+    files_and_dirs_name = Dir.glob('*')
+    formatted_list = push_elem_to_three_lists(files_and_dirs_name)
+  end
+
+  # 各配列の要素数を揃えるために、要素数が足りないリストにnilを入れる
+  max_elem = formatted_list.max_by(&:size).size
+  output_list = formatted_list.each do |elem|
+    elem << nil while elem.size < max_elem
+  end
+
+  puts(output_list.transpose.map { |row| row.join(' ') })
+end
+
 def adjust_with_margin(list)
   max_chars = list.map(&:size).max
   list.map { |item| item.ljust(max_chars) }
@@ -17,25 +40,4 @@ def push_elem_to_three_lists(files_and_dirs_name)
   tmp_list
 end
 
-formatted_list = []
-
-opt = OptionParser.new
-opt.on('-a') do
-  files_and_dirs_name = Dir.entries('.')
-  formatted_list = push_elem_to_three_lists(files_and_dirs_name.sort)
-end
-opt.parse!(ARGV)
-
-if formatted_list.empty?
-  files_and_dirs_name = Dir.glob('*')
-  formatted_list = push_elem_to_three_lists(files_and_dirs_name)
-end
-
-# 各配列の要素数を揃えるために、要素数が足りないリストにnilを入れる
-max_elem = formatted_list.max_by(&:size).size
-output_list = formatted_list.each do |elem|
-  elem << nil while elem.size < max_elem
-end
-
-puts(output_list.transpose.map { |row| row.join(' ') })
-
+main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+require 'optparse'
+
 def adjust_with_margin(list)
   max_chars = list.map(&:size).max
   list.map { |item| item.ljust(max_chars) }
@@ -7,16 +9,33 @@ end
 
 # ターミナルの幅に関わらず横に最大３列を維持するため
 # ３つの配列に要素を詰める
-tmp_list = []
-files_and_dirs_name = Dir.glob('*')
-files_and_dirs_name.each_slice(files_and_dirs_name.size / 3 + 1) do |list|
-  tmp_list << adjust_with_margin(list)
+def push_elem_to_three_lists(files_and_dirs_name)
+  tmp_list = []
+  files_and_dirs_name.each_slice(files_and_dirs_name.size / 3 + 1) do |list|
+    tmp_list << adjust_with_margin(list)
+  end
+  tmp_list
+end
+
+formatted_list = []
+
+opt = OptionParser.new
+opt.on('-a') do
+  files_and_dirs_name = Dir.entries('.')
+  formatted_list = push_elem_to_three_lists(files_and_dirs_name.sort)
+end
+opt.parse!(ARGV)
+
+if formatted_list.empty?
+  files_and_dirs_name = Dir.glob('*')
+  formatted_list = push_elem_to_three_lists(files_and_dirs_name)
 end
 
 # 各配列の要素数を揃えるために、要素数が足りないリストにnilを入れる
-max_elem = tmp_list.max_by(&:size).size
-output_list = tmp_list.each do |elem|
+max_elem = formatted_list.max_by(&:size).size
+output_list = formatted_list.each do |elem|
   elem << nil while elem.size < max_elem
 end
 
 puts(output_list.transpose.map { |row| row.join(' ') })
+

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -3,18 +3,9 @@
 require 'optparse'
 
 def main
-  formatted_list = []
-  opt = OptionParser.new
-  opt.on('-a') do
-    files_and_dirs_name = Dir.entries('.')
-    formatted_list = push_elem_to_three_lists(files_and_dirs_name.sort)
-  end
-  opt.parse!(ARGV)
-
-  if formatted_list.empty?
-    files_and_dirs_name = Dir.glob('*')
-    formatted_list = push_elem_to_three_lists(files_and_dirs_name)
-  end
+  option = ARGV.getopts('a')
+  files_and_dirs_name = option['a'] ? Dir.entries('.').sort : Dir.glob('*')
+  formatted_list = push_elem_to_three_lists(files_and_dirs_name)
 
   # 各配列の要素数を揃えるために、要素数が足りないリストにnilを入れる
   max_elem = formatted_list.max_by(&:size).size


### PR DESCRIPTION
# 実行結果
## Macデフォルトのコマンド
<img width="743" alt="スクリーンショット 2024-03-05 19 01 12" src="https://github.com/triton27/ruby-practices/assets/48582930/5e361fe4-5baf-47f1-b573-dbaf7d9d7591">



## 自作コマンド
### 3列
<img width="591" alt="スクリーンショット 2024-03-05 19 00 50" src="https://github.com/triton27/ruby-practices/assets/48582930/8cc449e7-0d2b-488f-a882-77ef220966a2">

### 4列
<img width="764" alt="スクリーンショット 2024-03-06 20 33 42" src="https://github.com/triton27/ruby-practices/assets/48582930/e5440430-c852-4414-93c0-84b517f58ab9">


## rubocop
<img width="819" alt="スクリーンショット 2024-03-05 19 01 28" src="https://github.com/triton27/ruby-practices/assets/48582930/3739d430-4414-4941-9b7e-0c566e81d447">


