### PR TITLE
lsコマンドを作る3：-rオプションが使えるlsコマンドを実装する

### DIFF
--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -16,12 +16,7 @@ def main
   end
 
   formatted_list = push_elem_to_three_lists(files_and_dirs_name)
-
-  # 各配列の要素数を揃えるために、要素数が足りないリストにnilを入れる
-  max_elem = formatted_list.max_by(&:size).size
-  output_list = formatted_list.each do |elem|
-    elem << nil while elem.size < max_elem
-  end
+  output_list = def_nil_to_list(formatted_list)
 
   puts(output_list.transpose.map { |row| row.join(' ') })
 end
@@ -40,6 +35,14 @@ def push_elem_to_three_lists(files_and_dirs_name)
     tmp << adjust_with_margin(list)
   end
   tmp
+end
+
+def def_nil_to_list(formatted_list)
+  # 各配列の要素数を揃えるために、要素数が足りないリストにnilを入れる
+  max_elem = formatted_list.max_by(&:size).size
+  formatted_list.each do |elem|
+    elem << nil while elem.size < max_elem
+  end
 end
 
 main

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -5,14 +5,12 @@ require 'optparse'
 def main
   option = ARGV.getopts('a', 'r')
 
-  files_and_dirs_name = []
-  if option['a']
-    files_and_dirs_name = Dir.entries('.').sort
-  elsif option['r']
-    tmp = Dir.glob('*')
+  files_and_dirs_name = Dir.glob('*') unless option['a'] || option['r']
+  files_and_dirs_name = Dir.entries('.').sort if option['a']
+  if option['r']
+    tmp = files_and_dirs_name.nil? ? Dir.glob('*') : files_and_dirs_name
+    files_and_dirs_name = []
     files_and_dirs_name << tmp.pop while tmp.size.positive?
-  else
-    files_and_dirs_name = Dir.glob('*')
   end
 
   formatted_list = push_elem_to_three_lists(files_and_dirs_name)

--- a/04.ls/ls.rb
+++ b/04.ls/ls.rb
@@ -3,8 +3,18 @@
 require 'optparse'
 
 def main
-  option = ARGV.getopts('a')
-  files_and_dirs_name = option['a'] ? Dir.entries('.').sort : Dir.glob('*')
+  option = ARGV.getopts('a', 'r')
+
+  files_and_dirs_name = []
+  if option['a']
+    files_and_dirs_name = Dir.entries('.').sort
+  elsif option['r']
+    tmp = Dir.glob('*')
+    files_and_dirs_name << tmp.pop while tmp.size.positive?
+  else
+    files_and_dirs_name = Dir.glob('*')
+  end
+
   formatted_list = push_elem_to_three_lists(files_and_dirs_name)
 
   # 各配列の要素数を揃えるために、要素数が足りないリストにnilを入れる
@@ -23,12 +33,13 @@ end
 
 # ターミナルの幅に関わらず横に最大３列を維持するため
 # ３つの配列に要素を詰める
+MAXIMAM_COLUMNS = 3
 def push_elem_to_three_lists(files_and_dirs_name)
-  tmp_list = []
-  files_and_dirs_name.each_slice(files_and_dirs_name.size / 3 + 1) do |list|
-    tmp_list << adjust_with_margin(list)
+  tmp = []
+  files_and_dirs_name.each_slice(files_and_dirs_name.size / MAXIMAM_COLUMNS + 1) do |list|
+    tmp << adjust_with_margin(list)
   end
-  tmp_list
+  tmp
 end
 
 main


### PR DESCRIPTION
# 実行結果
## Macデフォルトのコマンド
### -r
<img width="590" alt="スクリーンショット 2024-03-29 23 55 37" src="https://github.com/triton27/ruby-practices/assets/48582930/ea07a922-1e17-435d-91c1-4f493260c258">

### -ar
<img width="702" alt="スクリーンショット 2024-03-29 23 49 03" src="https://github.com/triton27/ruby-practices/assets/48582930/64484ee3-b3b1-4c87-a62e-2dce8a4f1ded">


## 自作コマンド
### -r
<img width="574" alt="スクリーンショット 2024-03-29 23 54 13" src="https://github.com/triton27/ruby-practices/assets/48582930/76e4fcb7-0330-4dfa-9f37-286444dc6872">

### -ar
<img width="711" alt="スクリーンショット 2024-03-29 23 48 18" src="https://github.com/triton27/ruby-practices/assets/48582930/5e8a2be3-4f61-4ec8-87fe-8867b22a5c10">

## rubocop
<img width="566" alt="スクリーンショット 2024-03-29 23 56 28" src="https://github.com/triton27/ruby-practices/assets/48582930/c35ad1bf-b6cb-497f-bf6f-6090d98261a9">





